### PR TITLE
fix(ObjectDescriptionFactory): swap function_exists with enum_exists

### DIFF
--- a/src/Factories/ObjectDescriptionFactory.php
+++ b/src/Factories/ObjectDescriptionFactory.php
@@ -81,8 +81,8 @@ final class ObjectDescriptionFactory
         }
 
         return match (true) {
-            enum_exists($use) => (new \ReflectionEnum($use))->isUserDefined(),
             function_exists($use) => (new ReflectionFunction($use))->isUserDefined(),
+            enum_exists($use) => (new \ReflectionEnum($use))->isUserDefined(),
             class_exists($use) => (new ReflectionClass($use))->isUserDefined(),
             interface_exists($use) => (new ReflectionClass($use))->isUserDefined(),
             // ...


### PR DESCRIPTION
The `function_exists()` function should be used first, so that the `enum_exists()` doesn't cause the composer autoloader to try to include a file that has already been included.

Basically, it is [composer](https://github.com/composer/composer/issues/6987#issue-286629049) who should fix this, but they have decided it works fine.

**To reproduce:** 

1. Add a class with using a function like `use function Psl\Str\Byte\pad_left` in `\App` namespace.
2. Add any rule with `\App` as target, for example: `arch()->expect('App')->not->toImplement(Throwable::class)`
3. Run the test

**Result:** PHP Fatal error:  Cannot redeclare Psl\Str\Byte\pad_left()